### PR TITLE
Remove unused modules

### DIFF
--- a/mistocr/api.py
+++ b/mistocr/api.py
@@ -5,10 +5,8 @@ Handles communication with the Mistral AI OCR API.
 """
 
 import os
-import base64
 import requests
-from pathlib import Path
-from typing import Dict, List, Optional, Any, Union
+from typing import Dict, List, Optional, Any
 
 
 MISTRAL_API_URL = "https://api.mistral.ai/v1/ocr"

--- a/mistocr/formatter.py
+++ b/mistocr/formatter.py
@@ -14,7 +14,6 @@ from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Image as RL
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.units import inch
 from reportlab.lib import colors
-from PIL import Image
 
 
 def format_as_markdown(
@@ -156,7 +155,6 @@ def format_as_pdf(
     
     # Define styles
     styles = getSampleStyleSheet()
-    title_style = styles['Heading1']
     normal_style = styles['Normal']
     
     # Create a custom style for page headers


### PR DESCRIPTION
## Summary
- clean up `mistocr/api.py` unused imports
- drop pillow import and unused variable in `mistocr/formatter.py`

## Testing
- `python -m py_compile mistocr/api.py mistocr/formatter.py`
- `flake8 mistocr/api.py mistocr/formatter.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c392dfe2c8331bce1334e41754585