### PR TITLE
Add unit tests for CLI and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ Output plain text instead of markdown:
 mistocr document.pdf -f text -o output.txt
 ```
 
+## Running Tests
+
+The test suite uses `pytest`. After installing the project dependencies,
+execute the tests from the repository root:
+
+```bash
+pytest
+```
+
 ## License
 
-MIT License 
+MIT License

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+import pytest
+from mistocr.cli import parse_pages
+
+
+def test_parse_pages_none():
+    assert parse_pages(None) is None
+    assert parse_pages('') is None
+
+
+def test_parse_pages_list():
+    assert parse_pages('0,1,2') == [0, 1, 2]
+
+
+def test_parse_pages_range():
+    assert parse_pages('0-2') == [0, 1, 2]
+
+
+def test_parse_pages_mixed():
+    assert parse_pages('1,3-5,7') == [1, 3, 4, 5, 7]
+
+
+@pytest.mark.parametrize('arg', ['a,b', '1-', '-2', '1,a'])
+def test_parse_pages_invalid(arg):
+    with pytest.raises(ValueError):
+        parse_pages(arg)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,48 @@
+import base64
+from pathlib import Path
+
+import pytest
+
+from mistocr.formatter import format_as_markdown, format_as_text
+
+
+@pytest.fixture
+def minimal_response():
+    return {
+        "pages": [
+            {
+                "index": 0,
+                "markdown": "# Heading\nSome *text*.",
+                "images": [
+                    {
+                        "id": "img1",
+                        "image_base64": base64.b64encode(b"data").decode()
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def test_format_as_markdown_embed(minimal_response):
+    output = format_as_markdown(minimal_response, include_images=True)
+    assert "## Page 1" in output
+    assert "# Heading" in output
+    assert "data:image/png;base64," in output
+
+
+def test_format_as_markdown_save(tmp_path, minimal_response, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out_dir = tmp_path / "imgs"
+    output = format_as_markdown(minimal_response, include_images=True, output_dir=str(out_dir))
+    img_path = out_dir / "page_0_image_0.png"
+    assert img_path.exists()
+    assert f"![Image 1 from page 1](imgs/page_0_image_0.png)" in output
+    assert img_path.read_bytes() == b"data"
+
+
+def test_format_as_text(minimal_response):
+    output = format_as_text(minimal_response)
+    assert "--- Page 1 ---" in output
+    assert "Heading" in output
+    assert "Some text." in output


### PR DESCRIPTION
## Summary
- add pytest-based test suite
- cover `parse_pages` in CLI and markdown/text formatting
- document how to run the test suite

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_683c394fc90083318415453ef69f90ef